### PR TITLE
Fix syntax error in fleet component

### DIFF
--- a/frontend/src/components/Fleet.js
+++ b/frontend/src/components/Fleet.js
@@ -159,8 +159,8 @@ const Fleet = () => {
                         </div>
                       ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                )}
 
                 {ship.mounts && ship.mounts.length > 0 && (
                   <div className="mounts-section">
@@ -174,6 +174,7 @@ const Fleet = () => {
                     </div>
                   </div>
                 )}
+              </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Fix JSX nesting for conditional rendering blocks in `Fleet.js` to resolve a build-breaking `SyntaxError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c0a3943-0e20-41b2-b847-5d853f7e2504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c0a3943-0e20-41b2-b847-5d853f7e2504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

